### PR TITLE
Add the key_id_header module and start on functions for dealing with it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 aes-gcm = "0.10.3"
 bytes = "1"
 hmac = { version = "0.12", features = ["std"] }
+itertools = "0.11.0"
 protobuf = { version = "3.3", features = ["with-bytes"] }
 rand = "0.8.5"
 sha2 = "0.10"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
             "src/dcp_edek.proto",
             "src/cmk_edek.proto",
             "src/icl_header_v4.proto",
-            "src/vector_encryption_header.proto",
+            "src/vector_encryption_metadata.proto",
         ])
         .include("src")
         .customize(

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -110,7 +110,7 @@ impl KeyIdHeader {
     }
 
     /// Write this header onto the front of the document.
-    pub fn put_header_on_document(&self, document: Bytes) -> Bytes {
+    pub fn put_header_on_document<U: IntoIterator<Item = u8>>(&self, document: Bytes) -> Bytes {
         self.write_to_bytes().into_iter().chain(document).collect()
     }
 

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -47,16 +47,13 @@ impl PayloadType {
 
     pub(crate) fn from_numeric_value(candidate: &u8) -> Result<PayloadType> {
         let masked_candidate = candidate & 0x0F; // Mask off the top 4 bits.
-        if masked_candidate == DETERMINISTIC_PAYLOAD_TYPE_NUM {
-            Ok(PayloadType::DeterministicField)
-        } else if masked_candidate == VECTOR_METADATA_PAYLOAD_TYPE_NUM {
-            Ok(PayloadType::VectorMetadata)
-        } else if masked_candidate == STANDARD_EDEK_PAYLOAD_TYPE_NUM {
-            Ok(PayloadType::StandardEdek)
-        } else {
-            Err(Error::PayloadTypeError(
-                "Byte {candidate} isn't a valid payload type.".to_string(),
-            ))
+        match masked_candidate {
+            DETERMINISTIC_PAYLOAD_TYPE_NUM => Ok(PayloadType::DeterministicField),
+            VECTOR_METADATA_PAYLOAD_TYPE_NUM => Ok(PayloadType::VectorMetadata),
+            STANDARD_EDEK_PAYLOAD_TYPE_NUM => Ok(PayloadType::StandardEdek),
+            _ => Err(Error::PayloadTypeError(format!(
+                "Byte {masked_candidate} isn't a valid payload type."
+            ))),
         }
     }
 }
@@ -79,16 +76,13 @@ impl EdekType {
 
     pub(crate) fn from_numeric_value(candidate: &u8) -> Result<EdekType> {
         let masked_candidate = candidate & 0xF0; // Mask off the bottom 4 bits.
-        if masked_candidate == SAAS_SHIELD_EDEK_TYPE_NUM {
-            Ok(EdekType::SaasShield)
-        } else if masked_candidate == STANDALONE_EDEK_TYPE_NUM {
-            Ok(EdekType::Standalone)
-        } else if masked_candidate == DCP_EDEK_TYPE_NUM {
-            Ok(EdekType::DataControlPlatform)
-        } else {
-            Err(Error::EdekTypeError(format!(
+        match masked_candidate {
+            SAAS_SHIELD_EDEK_TYPE_NUM => Ok(EdekType::SaasShield),
+            STANDALONE_EDEK_TYPE_NUM => Ok(EdekType::Standalone),
+            DCP_EDEK_TYPE_NUM => Ok(EdekType::DataControlPlatform),
+            _ => Err(Error::EdekTypeError(format!(
                 "Byte {masked_candidate} isn't a valid edek type."
-            )))
+            ))),
         }
     }
 }

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -43,13 +43,10 @@ impl EdekType {
         }
     }
     pub fn create_header(&self, key_id: KeyId) -> Bytes {
-        let mut vec = Vec::with_capacity(6);
-        for b in u32::to_be_bytes(key_id.0) {
-            vec.push(b);
-        }
-        vec.push(self.to_numeric_value());
-        vec.push(0u8);
-        vec.into()
+        let iter = u32::to_be_bytes(key_id.0)
+            .into_iter()
+            .chain([self.to_numeric_value(), 0u8]);
+        Bytes::from_iter(iter)
     }
 
     pub(crate) fn parse_from_bytes(b: Bytes) -> Result<EdekType> {

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -108,6 +108,12 @@ impl KeyIdHeader {
             key_id,
         }
     }
+
+    /// Write this header onto the front of the document.
+    pub fn put_header_on_document(&self, document: Bytes) -> Bytes {
+        self.write_to_bytes().into_iter().chain(document).collect()
+    }
+
     /// Write the header to bytes. This is done by writing the key_id to be 4 bytes, putting the edek and payload types into
     /// the next byte and padding with a zero. See the comment at the top of this file for more information.
     pub fn write_to_bytes(&self) -> Bytes {

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -24,7 +24,7 @@ pub enum EdekType {
 }
 
 impl EdekType {
-    pub(crate) fn to_numeric_value(&self) -> u8 {
+    pub(crate) fn to_numeric_value(self) -> u8 {
         match self {
             EdekType::SaasShield => SAAS_SHIELD_EDEK_TYPE_NUM,
             EdekType::Standalone => STANDALONE_EDEK_TYPE_NUM,
@@ -68,8 +68,8 @@ pub fn create_vector_metadata(
 ) -> (Bytes, VectorEncryptionMetadata) {
     let key_id_header = edek_type.create_header(key_id.0);
     let vector_encryption_metadata = VectorEncryptionMetadata {
-        iv: iv.into(),
-        auth_hash: auth_hash.into(),
+        iv,
+        auth_hash,
         ..Default::default()
     };
     (key_id_header, vector_encryption_metadata)

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 use protobuf::Message;
 
 use crate::{vector_encryption_metadata::VectorEncryptionMetadata, Error};
+use std::fmt::Display;
 
 // This file is for functions which are working with our key id header value.
 // This value has the following structure:
@@ -36,6 +37,16 @@ pub enum PayloadType {
     StandardEdek,
 }
 
+impl Display for PayloadType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PayloadType::DeterministicField => write!(f, "Deterministic Field"),
+            PayloadType::VectorMetadata => write!(f, "Vector Metadata"),
+            PayloadType::StandardEdek => write!(f, "Standard EDEK"),
+        }
+    }
+}
+
 impl PayloadType {
     pub(crate) fn to_numeric_value(self) -> u8 {
         match self {
@@ -63,6 +74,16 @@ pub enum EdekType {
     Standalone,
     SaasShield,
     DataControlPlatform,
+}
+
+impl Display for EdekType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EdekType::Standalone => write!(f, "Standalone"),
+            EdekType::SaasShield => write!(f, "SaaS Shield"),
+            EdekType::DataControlPlatform => write!(f, "Data Control Platform"),
+        }
+    }
 }
 
 impl EdekType {

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -42,9 +42,9 @@ impl EdekType {
             ))
         }
     }
-    pub fn create_header(&self, key_id: u32) -> Bytes {
+    pub fn create_header(&self, key_id: KeyId) -> Bytes {
         let mut vec = Vec::with_capacity(6);
-        for b in u32::to_be_bytes(key_id) {
+        for b in u32::to_be_bytes(key_id.0) {
             vec.push(b);
         }
         vec.push(self.to_numeric_value());
@@ -66,7 +66,7 @@ pub fn create_vector_metadata(
     iv: Bytes,
     auth_hash: Bytes,
 ) -> (Bytes, VectorEncryptionMetadata) {
-    let key_id_header = edek_type.create_header(key_id.0);
+    let key_id_header = edek_type.create_header(key_id);
     let vector_encryption_metadata = VectorEncryptionMetadata {
         iv,
         auth_hash,
@@ -109,6 +109,10 @@ pub fn decode_version_prefixed_value(mut value: Bytes) -> Result<(KeyId, EdekTyp
     } else {
         Err(Error::KeyIdHeaderTooShort(value_len))
     }
+}
+
+pub fn get_prefix_bytes_for_search(key_id: KeyId, edek_type: EdekType) -> Bytes {
+    edek_type.create_header(key_id)
 }
 
 #[cfg(test)]

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -1,0 +1,173 @@
+use bytes::Bytes;
+use itertools::Itertools;
+use protobuf::Message;
+
+use crate::{vector_encryption_metadata::VectorEncryptionMetadata, Error};
+
+// This file is for functions which are working with our key id header value.
+// This value has the following structure:
+// 4 Byte id. This value is a u32 encoded in big endian format.
+// 1 Byte where the first 4 bits are used for which type of edek the id points to (Standalone, Saas Shield, DCP).
+//   The next 4 bits are to denote which type of data follows it (vector metadata, IronCore Edoc, deterministic ciphertext)
+
+const SAAS_SHIELD_EDEK_TYPE_NUM: u8 = 0u8;
+const STANDALONE_EDEK_TYPE_NUM: u8 = 128u8;
+
+type Result<A> = std::result::Result<A, super::Error>;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EdekType {
+    SaasShield,
+    Standalone,
+}
+
+impl EdekType {
+    pub(crate) fn to_numeric_value(&self) -> u8 {
+        match self {
+            EdekType::SaasShield => SAAS_SHIELD_EDEK_TYPE_NUM,
+            EdekType::Standalone => STANDALONE_EDEK_TYPE_NUM,
+        }
+    }
+
+    pub(crate) fn from_numeric_value(candidate: &u8) -> Result<EdekType> {
+        if candidate == &SAAS_SHIELD_EDEK_TYPE_NUM {
+            Ok(EdekType::SaasShield)
+        } else if candidate == &STANDALONE_EDEK_TYPE_NUM {
+            Ok(EdekType::Standalone)
+        } else {
+            Err(Error::EdekTypeError(
+                "Byte {candidate} isn't a valid edek type.".to_string(),
+            ))
+        }
+    }
+    pub fn create_header(&self, key_id: u32) -> Bytes {
+        let mut vec = Vec::with_capacity(6);
+        for b in u32::to_be_bytes(key_id) {
+            vec.push(b);
+        }
+        vec.push(self.to_numeric_value());
+        vec.push(0u8);
+        vec.into()
+    }
+
+    pub(crate) fn parse_from_bytes(b: Bytes) -> Result<EdekType> {
+        b.first()
+            .ok_or_else(|| Error::EdekTypeError("EdekType couldn't be determined.".to_string()))
+            .and_then(Self::from_numeric_value)
+    }
+}
+
+// TODO: Payload type not implemented here yet.
+pub fn create_vector_metadata(
+    edek_type: EdekType,
+    key_id: KeyId,
+    iv: Bytes,
+    auth_hash: Bytes,
+) -> (Bytes, VectorEncryptionMetadata) {
+    let key_id_header = edek_type.create_header(key_id.0);
+    let vector_encryption_metadata = VectorEncryptionMetadata {
+        iv: iv.into(),
+        auth_hash: auth_hash.into(),
+        ..Default::default()
+    };
+    (key_id_header, vector_encryption_metadata)
+}
+
+/// Form the bytes that represent the vector metadata to the outside world.
+/// This is the protobuf with the key_id_header put onto the front.
+pub fn encode_vector_metadata(
+    key_id_header: Bytes,
+    vector_metadata: VectorEncryptionMetadata,
+) -> Bytes {
+    key_id_header
+        .into_iter()
+        .chain(
+            vector_metadata
+                .write_to_bytes()
+                .expect("Writing to in memory bytes failed"),
+        )
+        .collect_vec()
+        .into()
+}
+
+/// Decode a value which has the key_id_header put on the front by breaking it up.
+/// This returns the key id, edek type and the remaining bytes.
+pub fn decode_version_prefixed_value(mut value: Bytes) -> Result<(KeyId, EdekType, Bytes)> {
+    let value_len = value.len();
+    if value_len >= 6 {
+        let rest = value.split_off(6);
+        let padding_bytes = value.split_off(4);
+        let id = {
+            let id_byte_sized: [u8; 4] = value.to_vec().try_into().unwrap();
+            KeyId(u32::from_be_bytes(id_byte_sized))
+        };
+        // What's left in header is 2 bytes for the padding
+        let edek_type = EdekType::parse_from_bytes(padding_bytes)?;
+        Ok((id, edek_type, rest))
+    } else {
+        Err(Error::KeyIdHeaderTooShort(value_len))
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    #[test]
+    fn test_create_produces_saas_shield() {
+        let iv_bytes: Bytes = (1..12).collect_vec().into();
+        let auth_hash_bytes: Bytes = (1..16).collect_vec().into();
+        let (header, result) = create_vector_metadata(
+            EdekType::SaasShield,
+            KeyId(72000),
+            iv_bytes.clone(),
+            auth_hash_bytes.clone(),
+        );
+        assert_eq!(
+            header.to_vec(),
+            vec![0, 1, 25, 64, SAAS_SHIELD_EDEK_TYPE_NUM, 0]
+        );
+        assert_eq!(result.iv, iv_bytes);
+        assert_eq!(result.auth_hash, auth_hash_bytes);
+    }
+
+    #[test]
+    fn test_create_produces_standalone() {
+        let iv_bytes: Bytes = (1..12).collect_vec().into();
+        let auth_hash_bytes: Bytes = (1..16).collect_vec().into();
+        let (header, result) = create_vector_metadata(
+            EdekType::Standalone,
+            KeyId(72000),
+            iv_bytes.clone(),
+            auth_hash_bytes.clone(),
+        );
+        assert_eq!(
+            header.to_vec(),
+            vec![0, 1, 25, 64, STANDALONE_EDEK_TYPE_NUM, 0]
+        );
+        assert_eq!(result.iv, iv_bytes);
+        assert_eq!(result.auth_hash, auth_hash_bytes);
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let iv_bytes: Bytes = (1..12).collect_vec().into();
+        let auth_hash_bytes: Bytes = (1..16).collect_vec().into();
+        let key_id = KeyId(72000);
+        let (header, result) = create_vector_metadata(
+            EdekType::Standalone,
+            key_id,
+            iv_bytes.clone(),
+            auth_hash_bytes.clone(),
+        );
+
+        let encode_result = encode_vector_metadata(header, result.clone());
+        let (final_key_id, final_edek_type, final_vector_bytes) =
+            decode_version_prefixed_value(encode_result).unwrap();
+        assert_eq!(final_key_id, key_id);
+        assert_eq!(final_edek_type, EdekType::Standalone);
+        assert_eq!(final_vector_bytes, result.write_to_bytes().unwrap());
+    }
+}

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -110,7 +110,7 @@ impl KeyIdHeader {
     }
 
     /// Write this header onto the front of the document.
-    pub fn put_header_on_document<U: IntoIterator<Item = u8>>(&self, document: Bytes) -> Bytes {
+    pub fn put_header_on_document<U: IntoIterator<Item = u8>>(&self, document: U) -> Bytes {
         self.write_to_bytes().into_iter().chain(document).collect()
     }
 

--- a/src/key_id_header.rs
+++ b/src/key_id_header.rs
@@ -47,7 +47,7 @@ impl EdekType {
             ))
         }
     }
-    ///
+    /// Creates the key_id header for this edek type and the provided key_id.
     pub fn create_header(&self, key_id: KeyId) -> Bytes {
         let iter = u32::to_be_bytes(key_id.0)
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aes;
+pub mod key_id_header;
 mod signing;
 
 use self::icl_header_v4::V4DocumentHeader;
@@ -47,6 +48,11 @@ pub enum Error {
     EncryptError(String),
     /// Decryption of the edoc failed.
     DecryptError(String),
+    // The next errors have to do with the key_id_header
+    /// EdekType was not recognized
+    EdekTypeError(String),
+    /// key_id_header to short
+    KeyIdHeaderTooShort(usize),
 }
 
 impl Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ impl Display for Error {
             Error::HeaderLengthOverflow(x) => write!(f, "HeaderLengthOverflow({x})"),
             Error::EncryptError(x) => write!(f, "EncryptError({x})"),
             Error::DecryptError(x) => write!(f, "DecryptError({x})"),
+            Error::KeyIdHeaderTooShort(x) => write!(f, "KeyIdHeaderTooShort({x})"),
+            Error::EdekTypeError(x) => write!(f, "EdekTypeError({x})"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,12 @@ pub enum Error {
     // The next errors have to do with the key_id_header
     /// EdekType was not recognized
     EdekTypeError(String),
+    /// PayloadType was not recognized
+    PayloadTypeError(String),
     /// key_id_header to short
     KeyIdHeaderTooShort(usize),
+    /// key_id_header malformed
+    KeyIdHeaderMalformed(String),
 }
 
 impl Display for Error {
@@ -69,6 +73,8 @@ impl Display for Error {
             Error::DecryptError(x) => write!(f, "DecryptError({x})"),
             Error::KeyIdHeaderTooShort(x) => write!(f, "KeyIdHeaderTooShort({x})"),
             Error::EdekTypeError(x) => write!(f, "EdekTypeError({x})"),
+            Error::PayloadTypeError(x) => write!(f, "PayloadTypeError({x})"),
+            Error::KeyIdHeaderMalformed(x) => write!(f, "KeyIdHeaderMalformed({x})"),
         }
     }
 }

--- a/src/vector_encryption_metadata.proto
+++ b/src/vector_encryption_metadata.proto
@@ -5,6 +5,6 @@ option java_package = "com.ironcorelabs.proto";
 option java_outer_classname = "EncryptedDekProtos";
 
 message VectorEncryptionMetadata {
-    bytes iv = 2;
-    bytes auth_hash = 3;
+    bytes iv = 1;
+    bytes auth_hash = 2;
 }

--- a/src/vector_encryption_metadata.proto
+++ b/src/vector_encryption_metadata.proto
@@ -1,11 +1,10 @@
 syntax = "proto3";
-package ironcorelabs.proto.cloakedai;
+package ironcorelabs.proto.vector;
 
 option java_package = "com.ironcorelabs.proto";
 option java_outer_classname = "EncryptedDekProtos";
 
-message VectorEncryptionHeader {
-    uint32 secret_id = 1;
+message VectorEncryptionMetadata {
     bytes iv = 2;
     bytes auth_hash = 3;
 }


### PR DESCRIPTION
Adds create, encode and decode functions for dealing with key_id_headers. My plan is to leave this PR open until we implement the deterministic, vector and ironcore document versions in the SDK to ensure compatibility. Opening so we can get early feedback.