### PR TITLE
Add function to validate parsed V4DocumentHeader

### DIFF
--- a/src/v4/mod.rs
+++ b/src/v4/mod.rs
@@ -1,3 +1,5 @@
+use crate::icl_header_v4::V4DocumentHeader;
+
 pub mod aes;
 pub mod attached;
 
@@ -14,3 +16,11 @@ pub mod attached;
 pub(crate) const PRE_HEADER_LEN: usize = 7;
 pub(crate) const MAGIC: &[u8; 4] = b"IRON";
 pub(crate) const V4: u8 = 4u8;
+
+// Checks that the proto header has a signature, had a valid signature_type, has a signed_payload, and has at least one EDEK
+pub fn validate_v4_header(header: &V4DocumentHeader) -> bool {
+    header.signature_info.is_some()
+        && header.signature_info.signature_type.enum_value().is_ok()
+        && header.signed_payload.is_some()
+        && !header.signed_payload.edeks.is_empty()
+}


### PR DESCRIPTION
Open to suggestions about elsewhere to put this, but it didn't feel like `attached` or `aes` was right.