### PR TITLE
Add secret debug and macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.85.0"
 [dependencies]
 aes-gcm = "0.10.3"
 bytes = "1"
+hex = "0.4"
 hmac = { version = "0.12", features = ["std"] }
 itertools = "0.14.0"
 protobuf = { version = "3.3", features = ["with-bytes"] }

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -1,6 +1,6 @@
 // This module is dedicated with things to do with aes encryption/decryption.
 use super::Error;
-use crate::take_lock;
+use crate::{impl_secret_debug, take_lock};
 use aes_gcm::{AeadCore, Aes256Gcm, KeyInit, Nonce, aead::Aead, aead::Payload};
 use bytes::Bytes;
 use rand::{CryptoRng, RngCore};
@@ -64,8 +64,9 @@ pub struct EncryptedDocument(pub Vec<u8>);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaintextDocument(pub Vec<u8>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct EncryptionKey(pub [u8; 32]);
+impl_secret_debug!(EncryptionKey);
 
 /// Decrypt the AES encrypted payload using the key. Note that the IV is on the front of the payload.
 pub fn decrypt_document_with_attached_iv(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,11 @@ pub fn take_lock<T>(m: &Mutex<T>) -> MutexGuard<T> {
     })
 }
 
+/// This macro will allow a newtype that has a single tuple field to use a fingerprint instead of
+/// printing the secret value.
+/// struct Foo([u8;32])
+/// impl_secret_debug!(Foo);
+/// Then the debug will print something like Foo(<redacted:bda33dd3...>).
 #[macro_export]
 macro_rules! impl_secret_debug {
     ($t:ty) => {
@@ -131,6 +136,11 @@ macro_rules! impl_secret_debug {
     };
 }
 
+/// This macro will allow a newtype that has a single named field to use a fingerprint instead of
+/// printing the secret value.
+/// struct Foo {secret:[u8;32]}
+/// impl_secret_debug_named!(Foo, secret);
+/// Then the debug will print something like Foo{<redacted:bda33dd3...>}.
 #[macro_export]
 macro_rules! impl_secret_debug_named {
     ($t:ty, $field:ident) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ const CRATE_DEBUG_KEY: &str = match option_env!("MY_CRATE_DEBUG_KEY") {
 };
 
 /// Produce a short keyed hash for display in Debug impls.
-pub(crate) fn redacted_hash(data: &[u8]) -> String {
+pub fn redacted_hash(data: &[u8]) -> String {
     let mut mac = HmacSha256::new_from_slice(CRATE_DEBUG_KEY.as_ref())
         .expect("HMAC can take key of any size");
     mac.update(data);
@@ -124,7 +124,7 @@ macro_rules! impl_secret_debug {
                     f,
                     "{}(<redacted:{}...>)",
                     stringify!($t),
-                    crate::redacted_hash(self.0.as_ref())
+                    $crate::redacted_hash(self.0.as_ref())
                 )
             }
         }


### PR DESCRIPTION
Add macros to easily override the debug to just print a fingerprint instead. This also allows the person building using the ironcore-documents crate to choose the hmac key to use for that fingerprint. This means that anyone using this crate could change the fingerprint to not share a fingerprint with others who use this crate.

It uses this impl once inside the crate and we'll also use it in ironcore_alloy.

In case the motivation is unclear. This provides a person to know if 2 printed secret values are the same exact bytes without being able to determine the bytes.